### PR TITLE
feat: Create and enhance sqlite_preflight.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 **TL;DR – Run the one-liner below and you will get (a) a read-only safety copy of your `.db`, (b) an integrity-check/foreign-key log, and (c) a “feature inventory” text file listing every generated column, FTS5 table, `INTEGER PRIMARY KEY` alias, REAL-epoch field and JSON column.** After that you can move straight on to `pgloader` or the MySQL wizard without worrying about silent corruption or hidden SQLite-only quirks.
 
+## Prerequisites
+
+*   **Bash:** The script is written for Bash.
+*   **sqlite3:** The `sqlite3` command-line tool must be installed and available in your system's PATH.
+    *   On Debian/Ubuntu: `sudo apt update && sudo apt install sqlite3`
+    *   On macOS (using Homebrew): `brew install sqlite`
+    *   For other systems, please refer to your package manager or the official SQLite documentation.
+
 ```bash
 # --- sqlite_preflight.sh -------------------------------------------------
 #!/usr/bin/env bash
@@ -60,11 +68,12 @@ echo "✅ Pre-flight done.  Safe copy: $SAFE  |  Report: $LOG  |  Inventory: inv
 # ------------------------------------------------------------------------ 
 ```
 
-Save the file, make it executable (`chmod +x sqlite_preflight.sh`), then run:
+Save the file as `sqlite_preflight.sh`, make it executable (`chmod +x sqlite_preflight.sh`), then run:
 
 ```bash
-./sqlite_preflight.sh path/to/chat.db
+./sqlite_preflight.sh path/to/your_database.db
 ```
+Replace `path/to/your_database.db` with the actual path to your SQLite database file.
 
 ---
 
@@ -116,6 +125,20 @@ sqlite3 -readonly chat_readonly.db "SELECT name FROM sqlite_master WHERE type='t
 ```
 
 That’s it—you now have a bullet-proof, read-only source and a machine-generated checklist of SQLite-specific quirks, ready for a clean lift into PostgreSQL or MySQL.
+
+## Troubleshooting
+
+*   **`./sqlite_preflight.sh: command not found`**:
+    *   Make sure you've made the script executable: `chmod +x sqlite_preflight.sh`.
+    *   Ensure you are running it with `./` if it's in the current directory (e.g., `./sqlite_preflight.sh your_db.db`).
+*   **`Error: sqlite3 command not found. Please install sqlite3.`**:
+    *   This means the `sqlite3` tool is not installed or not in your PATH. Please see the "Prerequisites" section for installation instructions.
+*   **`cp: cannot stat 'your_db.db': No such file or directory`**:
+    *   The database file you specified does not exist at that path. Double-check the path to your database file.
+*   **`Error: Database integrity check failed.` (or similar message in the log file)**:
+    *   The script's log file (e.g., `preflight_YYYY-MM-DD_HHMM.log`) did not contain the expected "ok" from `PRAGMA integrity_check;`. This indicates potential corruption in your SQLite database. You **must** repair the database before attempting migration. Refer to SQLite documentation for repair options (e.g., `.recover` command in the SQLite shell).
+*   **Permissions errors when creating copy or logs**:
+    *   Ensure you have write permissions in the directory where you are running the script, as it needs to create a copy of the database and log files.
 
 [1]: https://linuxize.com/post/cp-command-in-linux/?utm_source=chatgpt.com "Cp Command in Linux (Copy Files)"
 [2]: https://www.tecmint.com/cp-command-examples/?utm_source=chatgpt.com "How to Use cp Command Effectively in Linux [14 Examples] - Tecmint"

--- a/sqlite_preflight.sh
+++ b/sqlite_preflight.sh
@@ -1,0 +1,81 @@
+# --- sqlite_preflight.sh -------------------------------------------------
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for command-line argument
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ./sqlite_preflight.sh <database_file_path>"
+    exit 1
+fi
+
+# Check for sqlite3 command
+if ! command -v sqlite3 &> /dev/null; then
+    echo "Error: sqlite3 command not found. Please install sqlite3."
+    exit 1
+fi
+
+DB="$1"                                   # chat.db (original)
+STAMP=$(date +%F_%H%M)
+SAFE="${DB%.db}_readonly_$STAMP.db"        # chat_readonly_2025-06-13_1810.db
+LOG="preflight_${STAMP}.log"              # full diagnostic log
+
+# 1. Copy & lock down ----------------------------------------------------------------
+cp --preserve=timestamps "$DB" "$SAFE" || { echo "Error: Failed to copy the database file."; exit 1; }
+chmod 0444 "$SAFE" || { echo "Error: Failed to set permissions for the database file."; exit 1; }
+
+# 2. Integrity & FK enforcement -------------------------------------------------------
+if ! sqlite3 -readonly "$SAFE" <<'SQL' >"$LOG" 2>&1; then
+PRAGMA foreign_keys = ON;      -- enforce constraints for this session :contentReference[oaicite:2]{index=2}
+PRAGMA integrity_check;        -- deep corruption scan (prints “ok” if clean) :contentReference[oaicite:3]{index=3}
+SQL
+    echo "Error: sqlite3 command failed during integrity check. Check $LOG for details."
+    exit 1
+fi
+
+# Check if integrity check passed (sqlite3 prints "ok" on success)
+if ! grep -q "ok" "$LOG"; then
+    echo "Error: Database integrity check failed. Check $LOG for details."
+    exit 1
+fi
+
+# 3. Feature inventory into separate file -------------------------------------------
+if ! sqlite3 -readonly "$SAFE" <<'SQL' > "inventory_${STAMP}.txt" 2>&1; then
+.headers on
+.mode column
+-- Generated / hidden columns
+SELECT tbl_name AS table_name
+FROM sqlite_master
+WHERE type='table'
+  AND sql LIKE '%GENERATED ALWAYS%';               -- detects stored generated cols :contentReference[oaicite:4]{index=4}
+
+-- FTS5 virtual tables
+SELECT name AS fts5_table
+FROM sqlite_master
+WHERE type='table'
+  AND sql LIKE 'CREATE VIRTUAL TABLE%'
+  AND sql LIKE '%fts5%';                           -- FTS5 virtual tables :contentReference[oaicite:5]{index=5}
+
+-- INTEGER PRIMARY KEY aliases (rowid)
+SELECT tbl_name AS table_name
+FROM sqlite_master
+WHERE sql LIKE '%INTEGER PRIMARY KEY%';           -- rowid alias inspection :contentReference[oaicite:6]{index=6}
+
+-- REAL columns that look like Unix-epoch timestamps
+SELECT m.name AS table_name, p.name AS column_name
+FROM sqlite_master m
+JOIN pragma_table_info(m.name) p
+WHERE p.type='REAL'
+  AND (p.name LIKE '%_time' OR p.name LIKE '%_timestamp');
+
+-- Likely JSON blobs
+SELECT m.name, p.name
+FROM sqlite_master m
+JOIN pragma_table_info(m.name) p
+WHERE p.name LIKE '%_json' OR p.name LIKE '%json%'; -- spot JSON1 targets :contentReference[oaicite:7]{index=7}
+SQL
+    echo "Error: sqlite3 command failed during feature inventory. Check inventory_${STAMP}.txt for details."
+    exit 1
+fi
+
+echo "✅ Pre-flight done.  Safe copy: $SAFE  |  Report: $LOG  |  Inventory: inventory_${STAMP}.txt"
+# ------------------------------------------------------------------------


### PR DESCRIPTION
This commit introduces the `sqlite_preflight.sh` script, designed to help prepare SQLite databases for migration to other systems like PostgreSQL or MySQL.

Key features of the script:
- Creates a timestamped, read-only safety copy of the source database.
- Performs an integrity check and foreign key enforcement check, logging the output.
- Generates an inventory file listing SQLite-specific features (e.g., generated columns, FTS5 tables, INTEGER PRIMARY KEY aliases, REAL epoch fields, JSON columns) that might require attention during migration.

Enhancements include:
- Robust error handling:
    - Checks for the presence of the database file argument.
    - Verifies that `sqlite3` command is installed and accessible.
    - Provides clearer error messages for common issues.
    - Exits with appropriate status codes on failure.
- Improved guidance in README.md:
    - Added a "Prerequisites" section (Bash, sqlite3).
    - Included installation instructions for `sqlite3`.
    - Clarified script usage.
    - Added a "Troubleshooting" section for common problems.

I have tested the script for normal operation, argument handling, missing file errors, and simulated `sqlite3` unavailability.